### PR TITLE
Update __init__.py

### DIFF
--- a/rom/__init__.py
+++ b/rom/__init__.py
@@ -851,7 +851,7 @@ class Model(object):
             else:
                 if data:
                     pipe.hmset(key, data)
-                cls._gindex.index(conn, id_only, keys, scores, pipe=pipe)
+                    cls._gindex.index(conn, id_only, keys, scores, pipe=pipe)
 
             try:
                 pipe.execute()


### PR DESCRIPTION
bug : when user delete model object, idx data have revived.

----------usage----------------
someModel.delete()
# at this moment, idx and model object both deleted,

util.session.commit()
# at this moment, model data deleted but idx revived!

---

in delete() method, you coded 'session.add(self)'. 
I think your intention was that let the user keep tracking model object from session's 'known' memory even the user deleted before call session.commit().
So I suggest line 854's 'cls._gindex.index(..)' should be placed only when 'data' is not empty by line 852. That's why I put one more tab at 854 line.
