### PR TITLE
Fix for using prefix option and filtering

### DIFF
--- a/rom/index.py
+++ b/rom/index.py
@@ -227,6 +227,7 @@ class GeneralIndex(object):
                     pipe.zremrangebyscore(temp_id, _to_score(ma, True), 'inf')
             first = False
             intersect = pipe.zinterstore
+            pipe.execute() # ALP 29/05/2014, the changes are confirmed  in each round bukle 
         return pipe, intersect, temp_id
 
     def search(self, conn, filters, order_by, offset=None, count=None, timeout=None):


### PR DESCRIPTION
Sometimes it does not work as intended when you perform operations with the filter and prefix / suffix option.

The file affected is index.py, and the problem is solved adding “pipe.execute()” at the end of each iteration in the method “prepare”. The problem occurred when the first reorder filters was different to a prefix / suffix. The Lua code always is executed before the pipeline. In this situation when the first operation is different to suffix /  prefix Lua Script the logical algorithm changes the behavior.

I have create a unit test, with the change it works fine, but if you comment this line, the results are invalid.

The file with the unit test is “PrefixFilterNestTest.py”.

I have seen the new command redis command “zrangebylex”, I think it is interesting, and it could be usefull .

Best regards,
Alan.
