### PR TITLE
Enable session cache

### DIFF
--- a/test/test_alanperd.py
+++ b/test/test_alanperd.py
@@ -96,26 +96,25 @@ class TestFilter(unittest.TestCase):
             print c.name + " " + c.idPerson
         self.assertEqual(Person.query.like(idPerson='*94*').filter(description="ayuntamientodeburgos").count(),2)
     
-    
-    
-
 
 def get_person_by_age():
     import time 
     while True:
-        objPerson= Person.query.filter(edad=21).first()
-        print objPerson.name
-        time.sleep(5)
-        
+       objPerson= Person.query.filter(edad=21).limit(0,10).first()
+       print objPerson.name
+       time.sleep(5)
+
 if __name__ == '__main__':
     import time
     import threading
+    
     objPerson= Person.query.filter(edad=21).first()
     objPerson.name="Alan"
     objPerson.save()
     t = threading.Thread(target=get_person_by_age)
     t.daemon=True
     t.start()
+    time.sleep(1)
     
     objPerson= Person.query.filter(edad=21).first()
     objPerson.name="Juan"
@@ -128,7 +127,7 @@ if __name__ == '__main__':
     while True:
         print "--- Waiting ---"
         time.sleep(1)
-  
+    
     
     
     #objPerson.name="Alan"


### PR DESCRIPTION
Hello Josiah,
In this las pull request, I have included an option that allows to cache the response or not,  depending on the configuration according to a parameter.
In this way, throught a query you can force not to make the cache option.
In mutithread web enviroments we found some cases that we shouldn't use the cache option.
The implementation is carried an instance mode, but could be intersting to make it on a global enviroment.
I send you a test example that test this new feature.

I look forward to your comments.
Regards,
Alan Perd.
