### PR TITLE
Get rows count in all mehtod (one call)

### DIFF
--- a/rom/__init__.py
+++ b/rom/__init__.py
@@ -940,15 +940,15 @@ class Query(object):
             raise QueryError("You are missing filter or order criteria")
         return self._model._gindex.count(_connect(self._model), filters)
 
-    def _search(self,lstCount=None):
+    def _search(self,rowcount=None):
         if not (self._filters or self._order_by):
             raise QueryError("You are missing filter or order criteria")
         limit = () if not self._limit else self._limit
         
         
-        if lstCount<>None:
+        if rowcount<>None:
             return self._model._gindex.search(
-                _connect(self._model), self._filters, self._order_by, *limit,lstCount=lstCount)
+                _connect(self._model), self._filters, self._order_by, *limit,rowcount=rowcount)
         else:
             return self._model._gindex.search(
                 _connect(self._model), self._filters, self._order_by, *limit)
@@ -983,26 +983,26 @@ class Query(object):
         return self._model._gindex.search(
             _connect(self._model), self._filters, self._order_by, timeout=timeout)
 
-    def execute(self,lstCount=None):
+    def execute(self,rowcount=None):
         '''
         Actually executes the query, returning any entities that match the
         filters, ordered by the specified ordering (if any), limited by any
         earlier limit calls.
         '''
         
-        if (lstCount<>None):
-            return self._model.get(self._search(lstCount=lstCount))
+        if (rowcount<>None):
+            return self._model.get(self._search(rowcount=rowcount))
         else:
             return self._model.get(self._search())
             #ALP Option count is added in the search method.
 
-    def all(self,lstCount=None):
+    def all(self,rowcount=None):
         '''
         Alias for ``execute()``.
         '''
         
-        if lstCount<> None:
-            self.execute(lstCount=lstCount)
+        if rowcount<> None:
+            self.execute(rowcount=rowcount)
         else:        
             return self.execute()
 

--- a/rom/index.py
+++ b/rom/index.py
@@ -229,7 +229,7 @@ class GeneralIndex(object):
             intersect = pipe.zinterstore
         return pipe, intersect, temp_id
 
-    def search(self, conn, filters, order_by, offset=None, count=None, timeout=None,lstCount=None): #ALP
+    def search(self, conn, filters, order_by, offset=None, count=None, timeout=None,rowcount=None): #ALP
         '''
         Search for model ids that match the provided filters.
 
@@ -293,7 +293,7 @@ class GeneralIndex(object):
             pipe.execute()
             return temp_id
 
-        if (lstCount<>None):
+        if (rowcount<>None):
            pipe.zcard(temp_id) #ALP
         
         offset = offset if offset is not None else 0
@@ -304,8 +304,8 @@ class GeneralIndex(object):
         
         lst=pipe.execute()
         
-        if (lstCount<>None):
-           lstCount.append((lst[-3])) #ALP
+        if (rowcount<>None):
+           rowcount.append((lst[-3])) #ALP
         
         return lst[-2]
         

--- a/test/test_alanperd.py
+++ b/test/test_alanperd.py
@@ -95,26 +95,20 @@ class TestFilter(unittest.TestCase):
         for c in Person.query.like(idPerson='*94*').filter(description="ayuntamientodeburgos").all():
             print c.name + " " + c.idPerson
         self.assertEqual(Person.query.like(idPerson='*94*').filter(description="ayuntamientodeburgos").count(),2)
-        
+    
+    def test_rowcount(self):
+        CountPersons=[]
+        objPerson= Person.query.filter(edad=20).all(rowcount=CountPersons)
+        self.assertEqual(CountPersons[0],Person.query.filter(edad=20).count())
+   
 
 if __name__ == '__main__':
-
-    import time
-    import threading
-    
-    lstCount=[]
-    objPerson= Person.query.filter(edad=20).all(lstCount=lstCount)
-    objPerson= Person.query.filter(edad=20).all()
-    
-    print lstCount
-    
-    #for c in objPerson:
-    #    print c.name
-    
-    
-    print Person.query.filter(edad=20).count()
+    unittest.main()
+  
     
     """
+    util.use_null_session()
+    objPerson= Person.query.filter(edad=21).first()
     objPerson.name="Alan"
     objPerson.save()
     t = threading.Thread(target=get_person_by_age)
@@ -134,19 +128,20 @@ if __name__ == '__main__':
         print "--- Waiting ---"
         time.sleep(1)
     
-    
-    
+    """
     #objPerson.name="Alan"
     
     #objPerson.save()
     #print objPerson.name
     
     
->>>>>>> Option count is added in the search method.
-    unittest.main()
+    #unittest.main()
+    
+    
+    
+    
     #import time 
     #while True:
     #    print "This prints once a minute."
     #    time.sleep(60)
-    """
     


### PR DESCRIPTION
Hello again Josiah, 

I am gonna explain you in a few lines the problem and the adopted solution.

In the project which we are carrying out , the need to make data paging operations through Redis has come out.

Now making use of ROM, I have to make two queries. The first, to get the information but I have to specify a rows limit. (For example, “Person.query.filter(age=20).limit(0,2).all()”). The second, I need to get the total of rows affected by the query, so I have to make the following  query “Person.Query.filter(age=20).count()”.  This operation runs again the same query over Redis and it penalizes the performance for each paging operation. 

To improve in this aspect I have made a change in the code which allows to get the number of rows in one call. 

“Person.query.filter(age=20).all(rowcount=countperson)”.

Thanks a lot for all¡¡.

Regards, 
Alberto.
