### PR TITLE
added RestrictError, a test for it, and usage in Model.delete() for it.

### DIFF
--- a/rom/exceptions.py
+++ b/rom/exceptions.py
@@ -2,7 +2,7 @@
 __all__ = '''
     ORMError UniqueKeyViolation InvalidOperation
     QueryError ColumnError MissingColumn
-    InvalidColumnValue'''.split()
+    InvalidColumnValue RestrictError'''.split()
 
 class ORMError(Exception):
     'Base class for all ORM-related errors'
@@ -15,6 +15,9 @@ class InvalidOperation(ORMError):
 
 class QueryError(InvalidOperation):
     'Raised when arguments to ``Model.get_by()`` or ``Query.filter`` are not valid'
+
+class RestrictError(InvalidOperation):
+    'Raised when deleting an object referenced by other objects'
 
 class ColumnError(ORMError):
     'Raised when your column definitions are not kosher'


### PR DESCRIPTION
Hi @josiahcarlson

Here's the PR for https://github.com/josiahcarlson/rom/pull/34

I wrote my rough-draft idea of what a `Restrict` would look like in `rom`, I'd welcome some code review on this.

Some questions:
- I changed the order of another test so as not to trigger the RestrictError. I didn't totally understand the purpose of the test--- hope it's still okay.
- I am only checking the `OneToMany` fields for references to other models.  Since `ManyToOne` maintains the relationship, the opposite condition  (Tentacle being deleted before Octopus) is fine.

I also have a couple of inline comments you can see in the code.  Thanks!
