### PR TITLE
Test using tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,7 @@ upload:
 	python setup.py sdist upload
 
 test:
-	PYTHONPATH=`pwd` python2.6 test/test_rom.py
-	PYTHONPATH=`pwd` python2.7 test/test_rom.py
-	PYTHONPATH=`pwd` python3.3 test/test_rom.py
-	PYTHONPATH=`pwd` python3.4 test/test_rom.py
+	tox
 
 docs:
 	python -c "import rom; open('README.rst', 'wb').write(rom.__doc__); open('VERSION', 'wb').write(rom.VERSION);"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist    = py26,
+             py27,
+             py33,
+             py34
+[testenv]
+commands   = python test/test_rom.py
+deps       = redis
+
+[testenv:py26]
+basepython = python2.6
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py33]
+basepython = python3.3
+
+[testenv:py34]
+basepython = python3.4


### PR DESCRIPTION
Hey @josiahcarlson, I'm not sure if this interests you but I added some toxin configuration to run the tests. I've found it useful for testing with multiple versions and multiple package versions.  (The best use of tox was testing a django plugin over multiple versions of django and multiple versions python.)

Also, have you thought of setting up travis-ci for rom?  I'd be happy to help with that.
