### PR TITLE
Add tox and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+install:
+  - pip install tox
+script:
+  - make test-tox
+services:
+  - redis-server

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test:
 	PYTHONPATH=`pwd` python3.3 test/test_rom.py
 	PYTHONPATH=`pwd` python3.4 test/test_rom.py
 
+test-tox:
+	tox
+
 docs:
 	python -c "import rom; open('README.rst', 'wb').write(rom.__doc__); open('VERSION', 'wb').write(rom.VERSION);"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://travis-ci.org/josiahcarlson/rom.svg?branch=master
+    :target: https://travis-ci.org/josiahcarlson/rom
 
 Rom - the Redis object mapper for Python
 

--- a/test/test_rom.py
+++ b/test/test_rom.py
@@ -870,23 +870,27 @@ class TestORM(unittest.TestCase):
 
 
 def main():
+    testsFailed = False
     _disable_lua_writes()
     global_setup()
     print("Testing standard writing")
     try:
         unittest.main()
-    except SystemExit:
-        pass
+    except SystemExit as err:
+        testsFailed = testsFailed or err.code
     data = get_state()
     global_setup()
     _enable_lua_writes()
     print("Testing Lua writing")
     try:
         unittest.main()
-    except SystemExit:
-        pass
+    except SystemExit as err:
+        testsFailed = testsFailed or err.code
     lua_data = get_state()
     global_setup()
+
+    if testsFailed:
+        raise Exception("Tests failed.")
 
     ## if data != lua_data:
         ## print("WARNING: Regular/Lua data writing does not match!")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist    = py26,
+             py27,
+             py33,
+             py34
+[testenv]
+commands   = python test/test_rom.py
+deps       = redis
+
+[testenv:py26]
+basepython = python2.6
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py33]
+basepython = python3.3
+
+[testenv:py34]
+basepython = python3.4


### PR DESCRIPTION
- Added tox file
- Add travis.yml file, and tested it here: https://travis-ci.org/pconerly/rom
- Added `test-tox` to makefile.
- Added logic in `test_rom.py` to exit with the correct status code if either standard or lua-enabled tests failed.

@therealprologic, you're experienced with tox/travis, so let me know if there's anything I could change.

 @josiahcarlson let me know how this looks!
