### PR TITLE
[bug] Added two tests to show inconsistent order_by behavior

### DIFF
--- a/test/test_rom.py
+++ b/test/test_rom.py
@@ -869,6 +869,35 @@ class TestORM(unittest.TestCase):
         self.assertEqual(c.zcard('RomTestCleanOld:col1:idx'), 0)
 
 
+    def test_naked_order_by_num(self):
+        class RomTestNakedOrderByNum(Model):
+            num = Integer(index=True)
+
+        s = RomTestNakedOrderByNum(num=1)
+        s.save()
+        s = RomTestNakedOrderByNum(num=2)
+        s.save()
+
+        total = RomTestNakedOrderByNum.query.order_by('num').execute()
+        self.assertEqual(len(total), 2)
+        self.assertEqual(total[0].num, 1)
+        self.assertEqual(RomTestNakedOrderByNum.query.order_by('num').count(), 2)
+
+    def test_naked_order_by_string(self):
+        class RomTestNakedOrderByString(Model):
+            name = String(index=True) if six.PY2 else Text(index=True)
+
+        s = RomTestNakedOrderByString(name='a')
+        s.save()
+        s = RomTestNakedOrderByString(name='b')
+        s.save()
+
+        total = RomTestNakedOrderByString.query.order_by('name').execute()
+        self.assertEqual(len(total), 2)
+        self.assertEqual(total[0].name, 'a')
+        self.assertEqual(RomTestNakedOrderByString.query.order_by('name').count(), 2)
+
+
 def main():
     testsFailed = False
     _disable_lua_writes()


### PR DESCRIPTION
@josiahcarlson 

I ran into some really funky behavior when I was doing `query`es without `filter`s and with `order_by`.  At first I thought it wasn't working at all, but it's actually working for integer columns but not for string/text.

I investigated a little but I hit a wall at the `conn.pipeline()` object.  

`test_naked_order_by_num` passes, and `test_naked_order_by_string` fails.

https://travis-ci.org/pconerly/rom/builds/39043270

I'm not sure if this is a bug with rom or with redis?