### PR TITLE
_script_load() no longer fails to EVAL the script when EVALSHA fails on modern redis-py versions

### DIFF
--- a/rom/util.py
+++ b/rom/util.py
@@ -733,9 +733,8 @@ def _script_load(script):
                 return conn.execute_command(
                     "EVALSHA", sha[0], len(keys), *(keys+args))
 
-            except redis.exceptions.ResponseError as msg:
-                if not msg.args[0].startswith("NOSCRIPT"):
-                    raise
+            except redis.exceptions.NoScriptError:
+                pass
 
         return conn.execute_command(
             "EVAL", script, len(keys), *(keys+args))

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     license='GNU LGPL v2.1',
     long_description=long_description,
-    requires=['redis', 'six'],
-    install_requires=['redis', 'six'],
+    requires=['redis>=2.7.0', 'six'],
+    install_requires=['redis>=2.7.0', 'six'],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     license='GNU LGPL v2.1',
     long_description=long_description,
-    requires=['redis>=2.7.0', 'six'],
+    requires=['redis', 'six'],
     install_requires=['redis>=2.7.0', 'six'],
 )
 


### PR DESCRIPTION
This requires to declare compatibility with redis-py>=2.7.0 which is where the exception was introduced.
The current code does not work at least for 2.10.3.