### PR TITLE
Test against multiple redis versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
     - REDIS_VERSION=2.8
     - REDIS_VERSION=3.0
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install lxc-docker
   - docker pull redis:$REDIS_VERSION
   - docker run -d -p 6379:6379 redis:$REDIS_VERSION
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - REDIS_VERSION=3.0
 before_install:
   - docker pull redis:$REDIS_VERSION
-  - docker run -d -p 6379:6379 redis
+  - docker run -d -p 6379:6379 redis:$REDIS_VERSION
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: python
+sudo: required
+services:
+  - docker
+env:
+  matrix:
+    - REDIS_VERSION=2.6
+    - REDIS_VERSION=2.8
+    - REDIS_VERSION=3.0
+before_install:
+  - docker pull redis:$REDIS_VERSION
+  - docker run -d -p 6379:6379 redis
 install:
   - pip install tox
 script:
   - make test-tox
-services:
-  - redis-server


### PR DESCRIPTION
This pull request uses docker in Travis to pull different redis versions to test against.
Unfortunately docker only provides Redis>=2.6. Maybe it's time to drop support for 2.4 which is pretty old?