### PR TITLE
Adding support for fakeredis hook

### DIFF
--- a/rom/util.py
+++ b/rom/util.py
@@ -170,7 +170,8 @@ def set_connection_settings(*args, **kwargs):
     model-specific connections.
     '''
     global CONNECTION
-    CONNECTION = redis.Redis(*args, **kwargs)
+    redis_cls = kwargs.pop('redis_cls', redis.Redis)
+    CONNECTION = redis_cls(*args, **kwargs)
 
 def get_connection():
     '''


### PR DESCRIPTION
Currently if we have to use fakeredis* library for testing, we cannot do it since the connection hard codes redis.Redis connection class, I am providing the hook to override it. Also we could provide the StrictRedis class if we want to instead of providing default Redis one.

https://pypi.python.org/pypi/fakeredis