### PR TITLE
Avoid passing None to lua script

### DIFF
--- a/rom/util.py
+++ b/rom/util.py
@@ -968,7 +968,7 @@ class Lock(object):
     def _acquire(self):
         self.identifier = self.identifier or str(_random_hex(16))
         return _acquire_refresh_lock_with_timeout_lua(
-            self.conn, [self.lockname], [self.lock_timeout, self.identifier]) in ('OK', 1)
+            self.conn, [self.lockname], [self.lock_timeout, self.identifier or '']) in ('OK', 1)
 
     def acquire(self):
         acquired = False
@@ -987,7 +987,7 @@ class Lock(object):
         return refreshed
 
     def release(self):
-        return bool(_release_lock_lua(self.conn, [self.lockname], [self.identifier]))
+        return bool(_release_lock_lua(self.conn, [self.lockname], [self.identifier or '']))
 
     def __enter__(self):
         if not self.acquire():


### PR DESCRIPTION
After migrating to redis-py 3.0, passing `None` as an input will result
in an expection:

> redis-py 3.0 only accepts user data as bytes, strings or numbers
> (ints, longs and floats). Attempting to specify a key or a value as
> any other type will raise a DataError exception.

This breaks the implementation of `rom.util.Lock`.
The solution is to pass an empty string instead of `None` in case the
`identifier` property is `None`.