### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ is a huge waste and is the antithesis of good design.
 Instead, if you create a new ``expire_at`` float column with ``index=True``,
 the column can store when the entity is to expire. Then to expire the data, you
 can use: ``Model.query.filter(expire_at=(0, time.time())).limit(10)`` to (for
-example) get up to the 10 oldest entites that need to be expired.
+example) get up to the 10 oldest entities that need to be expired.
 
 Now, I know what you are thinking. You are thinking, "but I wish the data would
 just go away on its own." And I don't disagree. But for that to happen, Redis

--- a/docs/_static/jquery-1.11.1.js
+++ b/docs/_static/jquery-1.11.1.js
@@ -3898,7 +3898,7 @@ jQuery.fn.extend({
 			elem = this[0],
 			attrs = elem && elem.attributes;
 
-		// Special expections of .data basically thwart jQuery.access,
+		// Special expectations of .data basically thwart jQuery.access,
 		// so implement the relevant behavior ourselves
 
 		// Gets all values
@@ -6011,7 +6011,7 @@ function actualDisplay( name, doc ) {
 		// getDefaultComputedStyle might be reliably used only on attached element
 		display = window.getDefaultComputedStyle && ( style = window.getDefaultComputedStyle( elem[ 0 ] ) ) ?
 
-			// Use of this method is a temporary fix (more like optmization) until something better comes along,
+			// Use of this method is a temporary fix (more like optimization) until something better comes along,
 			// since it was removed from specification and supported only in FF
 			style.display : jQuery.css( elem[ 0 ], "display" );
 
@@ -6670,7 +6670,7 @@ jQuery.extend({
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 				style[ name ] = "inherit";
@@ -8135,7 +8135,7 @@ if ( !support.style ) {
 		get: function( elem ) {
 			// Return undefined in the case of empty string
 			// Note: IE uppercases css property names, but if we were to .toLowerCase()
-			// .cssText, that would destroy case senstitivity in URL's, like in "background"
+			// .cssText, that would destroy case sensitivity in URL's, like in "background"
 			return elem.style.cssText || undefined;
 		},
 		set: function( elem, value ) {

--- a/rom/__init__.py
+++ b/rom/__init__.py
@@ -161,7 +161,7 @@ is a huge waste and is the antithesis of good design.
 Instead, if you create a new ``expire_at`` float column with ``index=True``,
 the column can store when the entity is to expire. Then to expire the data, you
 can use: ``Model.query.filter(expire_at=(0, time.time())).limit(10)`` to (for
-example) get up to the 10 oldest entites that need to be expired.
+example) get up to the 10 oldest entities that need to be expired.
 
 Now, I know what you are thinking. You are thinking, "but I wish the data would
 just go away on its own." And I don't disagree. But for that to happen, Redis

--- a/rom/columns.py
+++ b/rom/columns.py
@@ -200,7 +200,7 @@ class Column(object):
           keygen will be used for both the regular *index* as well as the
           *prefix* and/or *suffix* searches
         * If *prefix* is set, you can perform pattern matches over your data.
-          See documention on ``Query.like()`` for details.
+          See documentation on ``Query.like()`` for details.
         * Pattern matching over data is only guaranteed to be valid or correct
           for ANSI strings that do not include nulls, though we make an effort
           to support unicode strings and strings with embedded nulls

--- a/rom/model.py
+++ b/rom/model.py
@@ -153,7 +153,7 @@ class _ModelMetaclass(type):
                 raise ColumnError("Single-column unique constraint: %r should be defined via 'unique=True' on the %r column"%(
                     comp, key[0]))
             if key in seen:
-                raise ColumnError("Multi-column unique constraint: %r not different than earlier constrant: %r"%(
+                raise ColumnError("Multi-column unique constraint: %r not different than earlier constraint: %r"%(
                     comp, seen[key]))
             for col in key:
                 if col not in columns:
@@ -240,7 +240,7 @@ class Model(six.with_metaclass(_ModelMetaclass, object)):
             ]
 
     .. note:: If one or more of the column values on an entity that is part of a
-        unique constrant is None in Python, the unique constraint won't apply.
+        unique constraint is None in Python, the unique constraint won't apply.
         This is the typical behavior of nulls in unique constraints inside both
         MySQL and Postgres.
     '''
@@ -839,7 +839,7 @@ class Model(six.with_metaclass(_ModelMetaclass, object)):
             the client on read + display. Or better yet; stick to integers.
           * *refresh_entities* - will refresh the entity data on transfer if
             ``True``-ish
-          * *refresh_index* - will refresh the update any relevant indexs after
+          * *refresh_index* - will refresh the update any relevant indexes after
             the transfer, if ``True``-ish; implies ``refresh_entities``
 
         ..warning: This doesn't magically create more bits for you. Values in

--- a/rom/query.py
+++ b/rom/query.py
@@ -151,7 +151,7 @@ class Query(object):
         .. warning:: If you use the ``_namedtuple_data_factory``, and your
           columns include underscore prefixes, they will be stripped. If this
           results in a name collision, you *will* get an exception. If you want
-          differerent behavior, write your own 20 line factory function that
+          different behavior, write your own 20 line factory function that
           does exactly what you want, and pass it; they are really easy!
 
         '''
@@ -250,7 +250,7 @@ class Query(object):
             value = self._check(attr, value, which='filter')
 
             if isinstance(value, NUMERIC_TYPES):
-                # for simple numeric equiality filters
+                # for simple numeric equality filters
                 value = (value, value)
 
             if isinstance(value, six.string_types):

--- a/rom/util.py
+++ b/rom/util.py
@@ -318,7 +318,7 @@ def IDENTITY(val):
 
     Where ``FULL_TEXT`` would transform a sentence like "A Simple Sentence" into
     an inverted index searchable by the words "a", "simple", and/or "sentence",
-    ``IDENTITY`` will only be searchable by the orginal full sentence with the
+    ``IDENTITY`` will only be searchable by the original full sentence with the
     same capitalization - "A Simple Sentence". See ``IDENTITY_CI`` for the
     same function, only case-insensitive.
     '''
@@ -422,7 +422,7 @@ class Session(threading.local):
     when you ``import rom`` as ``rom.session``.
 
     .. note:: calling ``.flush()`` or ``.commit()`` doesn't cause all objects
-        to be written simultanously. They are written one-by-one, with any
+        to be written simultaneously. They are written one-by-one, with any
         error causing the call to fail.
     '''
     def __init__(self, *args, **kwargs):
@@ -565,7 +565,7 @@ class Session(threading.local):
             session.delete([obj1, obj2, ...])
 
         The keyword argument ``force=True`` can be provided, which can force
-        the deletion of an entitiy again, even if we believe it to already be
+        the deletion of an entity again, even if we believe it to already be
         deleted.
 
         If ``force=True``, we won't re-call the object's ``_before_delete()``


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/_static/jquery-1.11.1.js
- rom/__init__.py
- rom/columns.py
- rom/model.py
- rom/query.py
- rom/util.py

Fixes:
- Should read `entities` rather than `entites`.
- Should read `specifying` rather than `specifing`.
- Should read `simultaneously` rather than `simultanously`.
- Should read `sensitivity` rather than `senstitivity`.
- Should read `original` rather than `orginal`.
- Should read `optimization` rather than `optmization`.
- Should read `indexes` rather than `indexs`.
- Should read `expectations` rather than `expections`.
- Should read `equality` rather than `equiality`.
- Should read `entity` rather than `entitiy`.
- Should read `documentation` rather than `documention`.
- Should read `different` rather than `differerent`.
- Should read `constraint` rather than `constrant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md